### PR TITLE
Set gitolite admin user

### DIFF
--- a/git-server/src/main/java/nl/tudelft/ewi/git/Config.java
+++ b/git-server/src/main/java/nl/tudelft/ewi/git/Config.java
@@ -48,5 +48,9 @@ public class Config {
 	public String getMirrorsDirectory() {
 		return properties.getProperty("gitolite.mirrors");
 	}
+
+	public String getGitoliteAdmin() {
+		return properties.getProperty("gitolite.admin.user", "git");
+	}
 	
 }

--- a/git-server/src/main/java/nl/tudelft/ewi/git/web/RepositoriesApi.java
+++ b/git-server/src/main/java/nl/tudelft/ewi/git/web/RepositoriesApi.java
@@ -164,7 +164,7 @@ public class RepositoriesApi extends BaseApi {
 			}
 		}
 
-		repository.setPermission(fetchUser(config, "git"), Permission.ALL);
+		repository.setPermission(fetchUser(config, configuration.getGitoliteAdmin()), Permission.ALL);
 
 		manager.apply(config);
 


### PR DESCRIPTION
I was running the Gitolite server from a Docker container ([image](https://registry.hub.docker.com/u/betacz/gitolite/)) which used a different administrator user. With this PR the used admin user for gitolite can be changed in the config. This can also be useful to set the gitolite admin to an actual system administrator and thus prevent repositories being accessed by creating the `git` account on the ldap server.