### PR TITLE
Fixed validation for user and group names according to Gitolite regexes

### DIFF
--- a/git-models/src/main/java/nl/tudelft/ewi/git/models/GroupModel.java
+++ b/git-models/src/main/java/nl/tudelft/ewi/git/models/GroupModel.java
@@ -18,7 +18,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 @EqualsAndHashCode(callSuper = true)
 public class GroupModel extends IdentifiableModel {
 
-	@Pattern(regexp = "^\\@[a-zA-Z0-9]+$")
+	@Pattern(regexp = "^\\@\\w[\\w._\\@+-]+$")
 	private String name;
 
 	@NotEmpty

--- a/git-models/src/main/java/nl/tudelft/ewi/git/models/UserModel.java
+++ b/git-models/src/main/java/nl/tudelft/ewi/git/models/UserModel.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Sets;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UserModel extends IdentifiableModel {
 
-	@Pattern(regexp = "^[a-zA-Z0-9]+$")
+	@Pattern(regexp = "^\\w[\\w._\\@+-]+$")
 	private String name;
 
 	@Setter(AccessLevel.PACKAGE)


### PR DESCRIPTION
This fixes issue https://github.com/devhub-tud/git-server/issues/34 (as close as we can get with Gitolite)
This is related to https://github.com/devhub-tud/Java-Gitolite-Manager/pull/17 on the Java-Gitolite-Manager, but that PR is not required for this PR as the preconditions introduced there are actually stronger than they were before.
Regexes taken from the originals in Gitolite: https://github.com/sitaramc/gitolite/blob/dc8b590a0562ab7dc4bdab9511fe6c31cb422ae8/src/lib/Gitolite/Rc.pm#L53