### PR TITLE
Sharing mirrors folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,10 +13,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
 	config.vm.synced_folder "~/.ssh", "/keys"
 	config.vm.synced_folder "puppet/files", "/vagrant/files"
-	
+
+    config.vm.synced_folder "/etc/git-server/mirrors", "/home/git/mirrors",
+    	mount_options: ["dmode=777", "fmode=666"]
+    config.vm.synced_folder "/etc/git-server/repositories", "/home/git/repositories",
+    	mount_options: ["dmode=777", "fmode=666"]
+
 	config.vm.provision "puppet" do |puppet|
 		puppet.options = "--verbose --debug"
 		puppet.manifests_path = "puppet/manifests"
 	end
-	
+    	
 end

--- a/puppet/files/hooks/post-receive
+++ b/puppet/files/hooks/post-receive
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-WORK_DIR="/etc/git-server/mirrors"
+WORK_DIR="/home/git/mirrors/"
 REPO_DIR="/home/git/repositories/"
 REPO_URL="$PWD"
 

--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -99,8 +99,12 @@ class gitolite::install {
 	
 	file { "/home/git/mirrors":
 		ensure		=> directory,
-		owner		=> "git",
-		group		=> "git",
+		mode		=> 777,
+		require		=> File["/home/git"],
+	}
+	
+	file { "/home/git/repositories":
+		ensure		=> directory,
 		mode		=> 777,
 		require		=> File["/home/git"],
 	}


### PR DESCRIPTION
While testing I found out that actually the bare repositories could be used to calculate diffs. This is strange because the mirrors folder was introduced in pull request #6 after the issue stating the exact opposite. Maybe this has to do with a newer version of JGit?