### PR TITLE
add an empty readme to new private repo's fixes #56

### DIFF
--- a/git-server/src/main/java/nl/tudelft/ewi/git/web/api/RepositoriesApiImpl.java
+++ b/git-server/src/main/java/nl/tudelft/ewi/git/web/api/RepositoriesApiImpl.java
@@ -146,6 +146,12 @@ public class RepositoriesApiImpl implements RepositoriesApi {
 				.setBare(false)
 				.call();
 
+			//if we can add a file do so
+			if( new File(repositoryDirectory,"README.md").createNewFile()) {
+				repo.add().addFilepattern("README.md").call();
+				repo.commit().setMessage("intial commit containing empty readme").call();
+			}
+
 			log.info("Pushing {} to {}", repositoryDirectory, repositoryUrl);
 			repo.push()
 				.setRemote(repositoryUrl)


### PR DESCRIPTION
this is a hacky fix for the issue, we still have the push to initialize the gitolite hooks, but we keep jgit happy when we push by having one ref to this commit. 

if we are not happy with the readme file in the repo we could also opt for an empty commit like:

    repo.commit().setAllowEmpty(true).setMessage("intial empty commit").call();