### PR TITLE
change the gitserver to not use the last / for the merge anymore

### DIFF
--- a/git-server/src/main/java/nl/tudelft/ewi/git/web/api/BranchApiImpl.java
+++ b/git-server/src/main/java/nl/tudelft/ewi/git/web/api/BranchApiImpl.java
@@ -89,7 +89,7 @@ public class BranchApiImpl extends AbstractDiffableApi implements BranchApi {
 				.setForce(true).call();
 
 			MergeResult ret = git.merge()
-				.include(repo.getRef("origin/" + branchName.substring(branchName.lastIndexOf('/') + 1)))
+				.include(repo.getRef(this.branchName.replace("refs/heads", "origin")))
 				.setStrategy(MergeStrategy.RECURSIVE)
 				.setSquash(false)
 				.setCommit(true)


### PR DESCRIPTION
The last index of / was the last thing breaking branchnames with /'s in them.