### PR TITLE
Fixed a concurrency problem that caused invalid 404s

### DIFF
--- a/git-server/pom.xml
+++ b/git-server/pom.xml
@@ -193,7 +193,7 @@
 		<dependency>
 			<groupId>nl.tudelft.ewi</groupId>
 			<artifactId>gitolite</artifactId>
-			<version>0.0.8</version>
+			<version>0.0.9</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>

--- a/git-server/src/main/java/nl/tudelft/ewi/git/web/exceptions/NotFoundExceptionMapper.java
+++ b/git-server/src/main/java/nl/tudelft/ewi/git/web/exceptions/NotFoundExceptionMapper.java
@@ -32,8 +32,7 @@ public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundExceptio
 				request.getMethod(),
 				request.getRequestURL(),
 				exception.getMessage()
-			),
-			exception
+			)
 		);
 
 		return Response.status(Status.NOT_FOUND)


### PR DESCRIPTION
Solution: bump gitolite to v0.0.9
* Fixes adding a duplicate key based on key contents
* Fixes a concurrent access problem in the RepositoriesManager

See: https://github.com/devhub-tud/Java-Gitolite-Manager/releases/tag/v0.0.9